### PR TITLE
improve recognition of svn repos using http(s) urls

### DIFF
--- a/lib/externals/scms/svn_project.rb
+++ b/lib/externals/scms/svn_project.rb
@@ -78,9 +78,9 @@ module Externals
         return true if $1.downcase == "svn"
       end
 
-# Look for http(s)://*/svn/*
+# Look for http(s)://*/*svn*/
       if path =~ /^https?:\/\/(?:[\w+\-_]+\.?)+\/(\w+)/
-        return true if $1.downcase == "svn"
+        return true if $1.downcase.include? "svn"
       end
 
       false


### PR DESCRIPTION
Now finds _svn_ instead of just svn; for instance google (svn) and sourceforge (svnroot) are both found.

Reset from azimux/externals master branch.
